### PR TITLE
Fix under-constraiend `ExtractStringFromPoint` circuit

### DIFF
--- a/circuits/ExtractStringFromPoint.circom
+++ b/circuits/ExtractStringFromPoint.circom
@@ -2,6 +2,21 @@ pragma circom 2.2.2;
 
 include "comparators.circom";
 
+template RShift1(N) {
+    signal input in;
+    signal output out;
+
+    component n2b = Num2Bits(N);
+    n2b.in <== in;
+    signal bits[N] <== n2b.out;
+
+    signal shifted_bits[N-1];
+    for (var i=0; i<N-1; i++) {
+        shifted_bits[i] <== bits[i+1];
+    }
+    out <== Bits2Num(N-1)(shifted_bits);
+}
+
 // This circuit is the circom equivalent of our `extract()` function from `curve.ts`.
 // It extracts an embedded string from a Ristretto point, and returns the string as individual bytes.
 // Since circom doesn't support strings, we represent the string as a series of bytes.
@@ -16,7 +31,9 @@ template ExtractStringFromPoint() {
     signal output stringAsBytes[maxLength];
 
     // Extract length from first byte (right shifted by 1)
-    signal shiftedFirstByte <-- (pointAsBytes[0] >> 1);
+    component rshift1 = RShift1(5);
+    rshift1.in <== pointAsBytes[0];
+    signal shiftedFirstByte <== rshift1.out;
     signal output length <== shiftedFirstByte;
 
     // Extract the embedded string bytes:


### PR DESCRIPTION
I also noticed a security vulnerability within the `ExtractStringFromPoint` circuit. Specifically, this circuit assigns the value to shiftedFirstByte with `<--` operator, which does not create a constraint. Consequently, the malicious prover can assign an arbitrary value to shiftedFirstByte, making a bogus proof.

https://github.com/siv-org/secretly-cancellable-votes/blob/7bda2311d7a33dcab611cfea0c67707b0b65c24c/circuits/ExtractStringFromPoint.circom#L19

For example, zkFuzz (https://github.com/Koukyosyumei/zkFuzz) has found the following malicious witness assignment: here, the prover can create a proof where `length = 1`, although the expected correct value is 0.

```
╔══════════════════════════════════════════════════════════════╗
║🚨 Counter Example:                                           ║
║    🔥 UnderConstrained (Non-Deterministic) 🔥
║           ➡️ `main.length` is expected to be `0`
║    🔍 Assignment Details:
║           ➡️ main.stringAsBytes[13] = 0
║           ➡️ main.pointAsBytes[12] = 1
║           ➡️ main.stringAsBytes[6] = 0
║           ➡️ main.pointAsBytes[23] = 21888242871839275222246405745257275088548364400416034343698204186575808495538
║           ➡️ main.pointAsBytes[10] = 9
║           ➡️ main.stringAsBytes[18] = 0
║           ➡️ main.stringAsBytes[30] = 0
║           ➡️ main.stringAsBytes[7] = 0
║           ➡️ main.length = 1
║           ➡️ main.pointAsBytes[30] = 2
║           ➡️ main.pointAsBytes[7] = 9
║           ➡️ main.pointAsBytes[14] = 0
║           ➡️ main.stringAsBytes[24] = 0
║           ➡️ main.stringAsBytes[5] = 0
║           ➡️ main.pointAsBytes[3] = 21888242871839275222246405745257275088548364400416034343698204186575808495553
║           ➡️ main.stringAsBytes[1] = 0
║           ➡️ main.stringAsBytes[26] = 0
║           ➡️ main.stringAsBytes[0] = 0
║           ➡️ main.pointAsBytes[31] = 21888242871839275222246405745257275088548364400416034343698204186575808495517
║           ➡️ main.pointAsBytes[25] = 21888242871839275222246405745257275088548364400416034343698204186575808495609
║           ➡️ main.shiftedFirstByte = 1
║           ➡️ main.pointAsBytes[8] = 8
║           ➡️ main.stringAsBytes[23] = 0
║           ➡️ main.stringAsBytes[10] = 0
║           ➡️ main.pointAsBytes[4] = 21888242871839275222246405745257275088548364400416034343698204186575808495608
║           ➡️ main.pointAsBytes[27] = 21888242871839275222246405745257275088548364400416034343698204186575808495523
║           ➡️ main.pointAsBytes[15] = 2
║           ➡️ main.pointAsBytes[22] = 21888242871839275222246405745257275088548364400416034343698204186575808495563
║           ➡️ main.stringAsBytes[16] = 0
║           ➡️ main.pointAsBytes[17] = 21888242871839275222246405745257275088548364400416034343698204186575808495523
║           ➡️ main.stringAsBytes[2] = 0
║           ➡️ main.stringAsBytes[28] = 0
║           ➡️ main.stringAsBytes[19] = 0
║           ➡️ main.pointAsBytes[20] = 21888242871839275222246405745257275088548364400416034343698204186575808495532
║           ➡️ main.pointAsBytes[21] = 0
║           ➡️ main.pointAsBytes[13] = 21888242871839275222246405745257275088548364400416034343698204186575808495581
║           ➡️ main.stringAsBytes[14] = 0
║           ➡️ main.pointAsBytes[28] = 2
║           ➡️ main.pointAsBytes[19] = 21888242871839275222246405745257275088548364400416034343698204186575808495537
║           ➡️ main.pointAsBytes[6] = 21888242871839275222246405745257275088548364400416034343698204186575808495533
║           ➡️ main.stringAsBytes[9] = 0
║           ➡️ main.pointAsBytes[18] = 21888242871839275222246405745257275088548364400416034343698204186575808495553
║           ➡️ main.pointAsBytes[16] = 21888242871839275222246405745257275088548364400416034343698204186575808495583
║           ➡️ main.pointAsBytes[2] = 21888242871839275222246405745257275088548364400416034343698204186575808495578
║           ➡️ main.stringAsBytes[29] = 0
║           ➡️ main.stringAsBytes[3] = 0
║           ➡️ main.stringAsBytes[25] = 0
║           ➡️ main.pointAsBytes[9] = 3
║           ➡️ main.stringAsBytes[8] = 0
║           ➡️ main.pointAsBytes[29] = 1
║           ➡️ main.stringAsBytes[11] = 0
║           ➡️ main.pointAsBytes[24] = 21888242871839275222246405745257275088548364400416034343698204186575808495556
║           ➡️ main.stringAsBytes[4] = 0
║           ➡️ main.stringAsBytes[27] = 0
║           ➡️ main.pointAsBytes[5] = 11988739823813317849392528959968755641729070055746106477955830395398190078275
║           ➡️ main.stringAsBytes[15] = 0
║           ➡️ main.pointAsBytes[26] = 3
║           ➡️ main.stringAsBytes[22] = 0
║           ➡️ main.pointAsBytes[1] = 0
║           ➡️ main.pointAsBytes[0] = 1
║           ➡️ main.pointAsBytes[11] = 9
║           ➡️ main.stringAsBytes[17] = 0
║           ➡️ main.stringAsBytes[20] = 0
║           ➡️ main.stringAsBytes[21] = 0
║           ➡️ main.stringAsBytes[12] = 0
```

As the fix, this PR proposes the following properly-constrained 1-bit right shift template:

```circom
template RShift1(N) {
    signal input in;
    signal output out;

    component n2b = Num2Bits(N);
    n2b.in <== in;
    signal bits[N] <== n2b.out;

    signal shifted_bits[N-1];
    for (var i=0; i<N-1; i++) {
        shifted_bits[i] <== bits[i+1];
    }
    out <== Bits2Num(N-1)(shifted_bits);
}
```

In addition, the LessThan circuit used in EmitIfInRange has a known vulnerability related to overflow, which can cause it to behave counterintuitively when handling values that exceed N bits. For example, consider the following witness assignment for EmitIfInRange(5). Here, the index is clearly larger than the range, although lt.out = 1. To prevent this issue, we need to use Num2Bits to rigorously check the bit length of the input. Details about this type of overflow issue can be found in the following repository: https://github.com/BlakeMScurr/comparator-overflow.

🎲 Random Seed: 971725914592168940
🧬 Generation: 0/500 (0)
    └─ Solution found in generation 0
╔══════════════════════════════════════════════════════════════╗
║🚨 Counter Example:                                           ║
║    🧟 UnderConstrained (Unexpected-Input) 🧟
║           Violated Condition: (BoolOr (BoolAnd (Eq 1 main.lt.out) (Lt [main.lt.in](http://main.lt.in/)[0] [main.lt.in](http://main.lt.in/)[1])) (BoolAnd (Eq 0 main.lt.out) (GEq [main.lt.in](http://main.lt.in/)[0] [main.lt.in](http://main.lt.in/)[1])))
║    🔍 Assignment Details:
║           ➡️ main.range = 5
║           ➡️ main.n = 5
║           ➡️ main.out = 3
║           ➡️ main.value = 3
║           ➡️ main.index = 21888242871839275222246405745257275088548364400416034343698204186575808495611
║           ➡️ main.lt.n2b.out[4] = 1
║           ➡️ main.lt.n2b.out[0] = 1
║           ➡️ main.lt.n2b.out[3] = 0
║           ➡️ [main.lt.n2b.in](http://main.lt.n2b.in/) = 21
║           ➡️ main.lt.n2b.out[2] = 1
║           ➡️ [main.lt.in](http://main.lt.in/)[1] = 5
║           ➡️ main.lt.out = 1
║           ➡️ main.lt.n2b.out[1] = 0
║           ➡️ [main.lt.in](http://main.lt.in/)[0] = 21888242871839275222246405745257275088548364400416034343698204186575808495611
║           ➡️ main.lt.n2b.out[5] = 0
╚══════════════════════════════════════════════════════════════╝

The proposed `RShift1` also addresses the problem, as it internally constrains the bit length of `length`.